### PR TITLE
Explicit is better than implicit.

### DIFF
--- a/Calcul Intégral I/Calcul Intégral I.md
+++ b/Calcul Intégral I/Calcul Intégral I.md
@@ -1386,6 +1386,10 @@ f(x) & \mbox{si $x \in \left]a,b\right[$,} \\
 \right.
 $$
 
+Une fonction $f$ définie sur un intervalle $I$ quelconque de $\R$ sera alors dite intégrable sur $I$
+si son extension $\bar{f}$ sur l'intervalle fermé $\bar{I}$ correspondant l'est,
+et l'intégrale de $f$ sur $I$ est alors *définie* comme l'intégrale de $\bar{f}$ sur $\bar{I}$.
+
 Si l'intervalle initial est borné,
 on s'est ramené au cas déjà étudié des intervalles fermés et bornés de $\R$.
 Mais si l'intervalle initial est non-borné, par exemple 


### PR DESCRIPTION
Désolé, je refais la même pull request parce que je l'avais faite depuis ma branch master, ce qui me coince pour avancer ;)
Ignorer la précédente ! (Que github a sagement fermée quand j'ai fait un push --force sur ma branch master ... je ne pensais pas qu'il serait si malin ;) )

Le passage de [a,b] à [-\infty,+\infty] est bien détaillé, mais le
passage de ]a,b[ à [a,b] était à moitié implicite
(on introduit l'extension par zéro à des fonctions définies sur un fermé, ok, mais on ne dit
jamais noir sur blanc que l'intégralle sur l'intervalle ouvert est
définie par l'intégrale de la fonction étendue à l'intervalle fermé,
et pas par une limite par exemple).

Visiblement, ce point était flou pour certains, vu que j'ai eu des questions dessus en tutorat de la forme "mais pourquoi l'intégrale de 1/sqrt(x) sur ]0,1[ correspond à celle de son prolongement par 0 ?", alors que la vision du cours est "par définition de l'intégrale sur un intervalle quelconque."

Je ne suis pas sûr de ce qui est le mieux entre :

    Définir l'intégrale sur un intervalle ouvert comme l'intégrale du prolongement, comme je le propose ici,
    Dire qu'on ne définit l'intégration que sur des intervalles fermés, en considérant toujours implicitement le prolongement par 0 aux bornes.

Les deux options sont au fond équivalentes, mais qu'est-ce qui est le plus clair ?